### PR TITLE
Add docker-compose.yml

### DIFF
--- a/back/proof/docker-compose.yml
+++ b/back/proof/docker-compose.yml
@@ -1,0 +1,32 @@
+version: '3'
+
+volumes:
+  openbdb-trial_mariadb:
+
+services:
+
+  openbdb-trial:
+    environment:
+      MYSQL_DATABASE: "${OPENBSRV_DBNAME}"
+      MYSQL_USER: "${OPENBSRV_DBUSER}"
+      MYSQL_PASSWORD: "${OPENBSRV_DBPASS}"
+      MYSQL_ROOT_PASSWORD: "${OPENBSRV_DBPASS}"
+    volumes:
+      - "openbdb-trial_mariadb:/var/lib/mysql"
+    build: "./openbdb"
+    restart: "unless-stopped"
+
+  openbsrv-trial:
+    depends_on:
+      - "openbdb-trial"
+    environment:
+      DBADDR: "openbdb-trial"
+      DBNAME: "${OPENBSRV_DBNAME}"
+      DBUSER: "${OPENBSRV_DBUSER}"
+      DBPASS: "${OPENBSRV_DBPASS}"
+      MIGRATETYPE: "${MIGRATETYPE:-migrate}"
+    ports:
+      - "${OPENBSRV_APIPORT:-4243}:4243"
+      - "${OPENBSRV_FRONTPORT:-4244}:4244"
+    build: "./openbsrv"
+    restart: "unless-stopped" 

--- a/back/proof/openbdb/Dockerfile
+++ b/back/proof/openbdb/Dockerfile
@@ -1,0 +1,15 @@
+FROM mariadb:10.2
+
+RUN apt-get update && apt-get dist-upgrade -y
+
+ENV MYSQL_ROOT_PASSWORD=""
+ENV MYSQL_DATABASE=""
+ENV MYSQL_USER=""
+ENV MYSQL_PASSWORD=""
+ENV MYSQL_ALLOW_EMPTY_PASSWORD = no
+ENV MYSQL_RANDOM_ROOT_PASSWORD = no
+
+ARG mycnf="/etc/mysql/my.cnf"
+RUN sed -Ei 's/^(.*)(bind-address\s+=\s+)[0-9][.0-9]{5,13}[0-9]/\20.0.0.0/g' ${mycnf}
+
+EXPOSE 3306

--- a/back/proof/openbsrv/Dockerfile
+++ b/back/proof/openbsrv/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine
 
 RUN apk add --update git libc6-compat
 
-RUN wget https://dl.google.com/go/go1.12.linux-amd64.tar.gz
+RUN wget https://dl.google.com/go/go1.12.1.linux-amd64.tar.gz
 RUN tar -C /usr/local -xzf go*.tar.gz
 RUN rm go*.tar.gz
 ENV PATH=${PATH}:/usr/local/go/bin
@@ -19,6 +19,20 @@ RUN git clone https://github.com/${repo} ${src}/${repo}
 WORKDIR ${src}/${repo}/back
 RUN go build -o ${go_bin}/openbsrv ./cmd/openbsrv/*.go
 
-ENTRYPOINT openbsrv -frontdir=${src}/${repo}/front/public
+ENV DBADDR=""
+ENV DBPORT=""
+ENV DBNAME=""
+ENV DBUSER=""
+ENV DBPASS=""
+ENV MIGRATETYPE=""
+
+ENTRYPOINT openbsrv \
+	${DBADDR/$DBADDR/-dbaddr=$DBADDR} \
+	${DBPORT/$DBPORT/-dbport=$DBPORT} \
+	${DBNAME/$DBNAME/-dbname=$DBNAME} \
+	${DBUSER/$DBUSER/-dbuser=$DBUSER} \
+	${DBPASS/$DBPASS/-dbpass=$DBPASS} \
+	${MIGRATETYPE/$MIGRATETYPE/-$MIGRATETYPE} \
+	-frontdir=${src}/${repo}/front/public
 
 EXPOSE 4243 4244


### PR DESCRIPTION
This will add a docker-compose config to test the project on bare machines using MariaDB 10.2 and Go 1.12.1. Retry with exponential backoff was also added to the initial DB ping to minimize failed starts (docker-compose does not ensure that any particular access is available when ordering service creation, only that the service boots).